### PR TITLE
Fix iptables package requirements for el7

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,27 @@
 ---
+- include_vars: '{{ item }}'
+  with_first_found:
+    - files:
+        - '{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml'
+      paths: '../vars'
 
 - name: ensure iptables rpm is installed
-  yum: 'pkg="{{ item }}" state="installed"'
-  with_items:
-    - 'iptables'
-    - 'libselinux-python'
+  yum:
+    name: '{{ item }}'
+    state: 'installed'
+  with_items: iptables_rpms
 
 - name: ensure the firewall is enabled and will start on boot
-  service: name=iptables state=started enabled=yes
+  service:
+    name: iptables
+    state:started
+    enabled: yes
 
 - name: create iptables configuration
-  template: src=iptables.j2 dest=/etc/sysconfig/iptables owner=root group=root mode=0600
+  template:
+    src: iptables.j2
+    dest: /etc/sysconfig/iptables
+    owner: root
+    group: root
+    mode: 0600
   notify: restart iptables

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: ensure the firewall is enabled and will start on boot
   service:
     name: iptables
-    state:started
+    state: started
     enabled: yes
 
 - name: create iptables configuration

--- a/vars/RedHat-6.yml
+++ b/vars/RedHat-6.yml
@@ -1,0 +1,4 @@
+---
+iptables_rpms:
+    - 'iptables'
+    - 'libselinux-python'

--- a/vars/RedHat-7.yml
+++ b/vars/RedHat-7.yml
@@ -1,0 +1,5 @@
+---
+iptables_rpms:
+    - 'iptables'
+    - 'iptables-services'
+    - 'libselinux-python'


### PR DESCRIPTION
Installs `iptables-services` on el7 hosts.  In addition, this updates the main tasks file to use the more formal `yaml` playbook syntax.
