### PR TITLE
Update main.yml (Ansible 2.x syntax)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
   yum:
     name: '{{ item }}'
     state: 'installed'
-  with_items: iptables_rpms
+  with_items: '{{ iptables_rpms }}'
 
 - name: ensure the firewall is enabled and will start on boot
   service:


### PR DESCRIPTION
Make task work with Ansible 2.x.

I've had followin error:

```
TASK [iptables : ensure iptables rpm is installed] *******************************************************************************************************************************************************************************************
Friday 03 August 2018  16:15:32 +0200 (0:00:00.097)       0:00:10.327 ********* 
failed: [iptables_host_1] (item=[u'iptables_rpms']) => {"changed": false, "item": ["iptables_rpms"], "msg": "No package matching 'iptables_rpms' found available, installed or updated", "rc": 126, "results": ["No package matching 'iptables_rpms' found available, installed or updated"]}
```

After the fix there is no error.

I'm using Ansible version 2.5.5.